### PR TITLE
SplitView now uses 1-pixel-wide divider

### DIFF
--- a/sidepane/MMCWTMSplitView.mm
+++ b/sidepane/MMCWTMSplitView.mm
@@ -42,7 +42,7 @@
 
 - (CGFloat)dividerThickness
 {
-    return 8.0;
+    return 1.0;
 }
 
 - (BOOL)sideBarOnRight;

--- a/sidepane/MMKFSplitView.m
+++ b/sidepane/MMKFSplitView.m
@@ -166,6 +166,7 @@ static BOOL kfScaleUInts(unsigned *integers, int numInts, unsigned targetTotal)
 
 - (void)kfSetup
 {
+    [self setDividerStyle:NSSplitViewDividerStyleThin];
     // be sure to setup cursors before calling setVertical:
     [self kfSetupResizeCursors];
 


### PR DESCRIPTION
I updated the NSSplitView/MMKFSplitView to use the 1-pixel-wide divider style (as seen in Mail.app, etc.) This should be more in keeping with OS X HIG.
